### PR TITLE
Model textarea style

### DIFF
--- a/index.html
+++ b/index.html
@@ -179,7 +179,7 @@
       <form>
           <div class="form-group">
             <label for="textArea">Describe your mechanism.</label>
-            <textarea class="form-control" id="textArea" rows="15" autocomplete="off">
+            <textarea class="form-control" id="textArea" rows="10" autocomplete="off">
 Growth-factor proteins activate EGFR, ERBB2, FGFR, PDGFR, MET, ROS1, and ALK.
 EGFR, ERBB2, PDGFR, MET, ROS1, ALK and FGFR activate GRB2 and SHC.
 GRB2 and SHC activate RASGRF and SOS.

--- a/index.html
+++ b/index.html
@@ -220,8 +220,7 @@ STK11 activates PRKAA, PRKAB and PRKAG.
 PRKAA, PRKAB and PRKAG deactivate mTORC2.
 mTORC2 deactivates EIF4EBP1.
 mTORC2 activates RPS6KB1 and RPS6KB2.
-TIAM activates RAC, which activates PAK.
-            </textarea>
+TIAM activates RAC, which activates PAK.</textarea>
           </div>
 
        </form>


### PR DESCRIPTION
show fewer rows in textarea for model
- this allows modal to fit entirely within screen of most devices
- otherwise "BUILD" button is off screen

get rid of blank space at the end of model text